### PR TITLE
add head predict and modify model

### DIFF
--- a/configs/ConvR.json
+++ b/configs/ConvR.json
@@ -7,7 +7,7 @@
 		"conv_out_channels": 100,
 		"conv_kernel_size": [5, 5],
 		"stride": 1,
-		"input_dropout": 0.2,
+		"input_dropout": 0.3,
 		"feature_map_dropout": 0.2,
 		"hidden_dropout": 0.3,
 		"label_smoothing": 0.1,
@@ -20,7 +20,7 @@
 	},
 	"train": {
 		"batch_size": 128,
-		"epochs": 5,
+		"epochs": 500,
 		"seed": 123,
 		"pretrain_model": null
 	},

--- a/evaluation.py
+++ b/evaluation.py
@@ -5,53 +5,75 @@ from tqdm import tqdm
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-def eval_for_tail(eval_data, model, device, data, descending):
+def eval_for_tail(config, eval_data, model, device, data, descending):
     # TODO: add reverse relations as https://github.com/TimDettmers/ConvE/ in training and evaluation
-    hits = []
+    hits_tail = []
+    hits_head = []
     ranks = []
     ent_rel_multi_t = data['entity_relation']['as_tail']
+    ent_rel_multi_h = data['entity_relation']['as_head']
+    rel_cnt = config.get('relation_cnt')
     for _ in range(10):  # need at most Hits@10
-        hits.append([])
+        hits_tail.append([])
+        hits_head.append([])
 
     for batch_idx, batch_data in enumerate(tqdm(eval_data)):
         eval_h = batch_data[0].to(device)
         eval_t = batch_data[1].to(device)
         eval_r = batch_data[2].to(device)
-        _, pred = model(eval_h, eval_r)  # evaluate corruptions by replacing the object, i.e. tail entity
-
+        _, pred_tail = model(eval_h, eval_r)  # evaluate corruptions by replacing the object, i.e. tail entity
+        _, pred_head = model(eval_t, eval_r + rel_cnt)
         # need to filter out the entities ranking above the target entity that form a
         # true (head, tail) entity pair in train/valid/test data
         for i in range(eval_h.size(0)):
             # get all tail entities that form triples with eval_h[i] as the head entity and eval_r[i] as the relation
             filter_t = ent_rel_multi_t[eval_h[i].item()][eval_r[i].item()]
+            filter_h = ent_rel_multi_h[eval_t[i].item()][eval_r[i].item()]
 
-            pred_value = pred[i][eval_t[i].item()].item()
-            pred[i][filter_t] = 0.0
-            pred[i][eval_t[i].item()] = pred_value
+            pred_tail_value = pred_tail[i][eval_t[i].item()].item()
+            pred_head_value = pred_head[i][eval_h[i].item()].item()
 
-        _, index = torch.sort(pred, 1, descending=True)  # pred: (batch_size, ent_count)
-        index = index.cpu().numpy()  # index: (batch_size)
+            pred_tail[i][filter_t] = 0.0
+            pred_head[i][filter_h] = 0.0
+
+            pred_tail[i][eval_t[i].item()] = pred_tail_value
+            pred_head[i][eval_h[i].item()] = pred_head_value
+
+        _, index_tail = torch.sort(pred_tail, 1, descending=True)
+        _, index_head = torch.sort(pred_head, 1, descending=True)  # pred: (batch_size, ent_count)
+
+        index_tail = index_tail.cpu().numpy()  # index: (batch_size)
+        index_head = index_head.cpu().numpy()
 
         for i in range(eval_h.size(0)):
             # find the rank of the target entities
-            rank = np.where(index[i] == eval_t[i].item())[0][0]
+            rank_tail = np.where(index_tail[i] == eval_t[i].item())[0][0]
+            rank_head = np.where(index_head[i] == eval_h[i].item())[0][0]
 
             # rank+1, since the rank starts with 1 not 0
-            ranks.append(rank + 1)
+            ranks.append(rank_tail + 1)
+            ranks.append(rank_head + 1)
 
             for hits_level in range(10):
-                if rank <= hits_level:
-                    hits[hits_level].append(1.0)
+                if rank_tail <= hits_level:
+                    hits_tail[hits_level].append(1.0)
                 else:
-                    hits[hits_level].append(0.0)
+                    hits_tail[hits_level].append(0.0)
 
-    return hits, ranks
+                if rank_head <= hits_level:
+                    hits_head[hits_level].append(1.0)
+                else:
+                    hits_head[hits_level].append(0.0)
+
+    return hits_tail, hits_head, ranks
 
 def output_eval_tail(results, data_name):
-    hits = np.array(results[0])
-    ranks = np.array(results[1])
+    hits_tail = np.array(results[0])
+    hits_head = np.array(results[1])
+    ranks = np.array(results[2])
     r_ranks = 1.0 / ranks  # compute reciprocal rank
 
     # print Hits@10, Hits@3, Hits@1, MR (mean rank), and MRR (mean reciprocal rank)
-    print('For %s data: Hits@10=%.4f - Hits@3=%.4f - Hits@1=%.4f' % (data_name, hits[9].mean(), hits[2].mean(), hits[0].mean()))
+    print('For %s data: hits_tail@10=%.4f - hits_tail@3=%.4f - hits_tail@1=%.4f' % (data_name, hits_tail[9].mean(), hits_tail[2].mean(), hits_tail[0].mean()))
+    print('For %s data: hits_head@10=%.4f - hits_head@3=%.4f - hits_head@1=%.4f' % (data_name, hits_head[9].mean(), hits_head[2].mean(), hits_head[0].mean()))
     print('For %s data: MR=%.4f - MRR=%.4f' % (data_name, ranks.mean(), r_ranks.mean()))

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ class Experiment:
             logging.error('Could not find corresponding optimizer for algorithm={}'.format(opt_conf.get('algorithm')))
         self.save_model_path = config.get('save_model_path')
     
-    def train_and_eval(self):
+    def train_and_eval(self, config):
         train_loader = DataLoader(self.dataset.data['train'], self.train_conf.get('batch_size'), shuffle=self.train_conf.get("shuffle"), drop_last=False)
         if self.dataset.data['valid']:
             valid_loader = DataLoader(self.dataset.data['valid'], self.eval_conf.get('batch_size'), shuffle=False, drop_last=False)
@@ -49,7 +49,7 @@ class Experiment:
         for epoch in range(self.train_conf.get('epochs')):
             logging.info('Start training epoch: %d' % (epoch + 1))
             start_time = time.time()
-            epoch_loss = self.train_func(train_loader, self.model, self.optimizer, self.device)
+            epoch_loss = self.train_func(config, train_loader, self.model, self.optimizer, self.device)
             end_time = time.time()
             mean_loss = np.mean(epoch_loss)
             print('[Epoch #%d] training loss: %f - training time: %.2f seconds' % (epoch + 1, mean_loss, end_time - start_time))
@@ -58,14 +58,14 @@ class Experiment:
                 logging.info('Start evaluation of validation data')
                 self.model.eval()
                 with torch.no_grad():
-                    eval_results = self.eval_func(valid_loader, self.model, self.device, self.dataset.data, self.eval_conf.get('scoring_desc'))
+                    eval_results = self.eval_func(config, valid_loader, self.model, self.device, self.dataset.data, self.eval_conf.get('scoring_desc'))
                     self.output_func(eval_results, 'validation')
         if self.eval_conf.get('do_test'):
             print(f'--- test ---')
             logging.info('Start evaluation on test data')
             self.model.eval()
             with torch.no_grad():
-                eval_results = self.eval_func(test_loader, self.model, self.device, self.dataset.data, self.eval_conf.get('scoring_desc'))
+                eval_results = self.eval_func(config, test_loader, self.model, self.device, self.dataset.data, self.eval_conf.get('scoring_desc'))
                 self.output_func(eval_results, 'test')
         if not os.path.exists(self.save_model_path):
             os.makedirs(self.save_model_path)
@@ -82,4 +82,4 @@ if __name__ == '__main__':
     print(config)
 
     experiment = Experiment(config)
-    experiment.train_and_eval()
+    experiment.train_and_eval(config)

--- a/models/ConvR.py
+++ b/models/ConvR.py
@@ -21,7 +21,7 @@ class ConvR(BaseModel):
         }
         assert self.emb_dim['entity'] == self.reshape[0] * self.reshape[1]
         self.E = torch.nn.Embedding(self.entity_cnt, self.emb_dim['entity'])
-        self.R = torch.nn.Embedding(self.relation_cnt, self.emb_dim['relation'])
+        self.R = torch.nn.Embedding(self.relation_cnt * 2, self.emb_dim['relation'])
         self.input_drop = torch.nn.Dropout(kwargs.get('input_dropout'))
         self.feature_map_drop = torch.nn.Dropout2d(kwargs.get('feature_map_dropout'))
         self.hidden_drop = torch.nn.Dropout(kwargs.get('hidden_dropout'))
@@ -33,7 +33,7 @@ class ConvR(BaseModel):
         self.filtered = [(self.reshape[0] - self.kernel_size[0]) // self.stride + 1,
                          (self.reshape[1] - self.kernel_size[1]) // self.stride + 1]
         fc_length = self.filtered[0] * self.filtered[1]
-        self.fc = torch.nn.Linear(fc_length, self.emb_dim['entity'])
+        self.fc = torch.nn.Linear(fc_length*self.conv_out_channels, self.emb_dim['entity'])
         self.loss = ConvRLoss(self.device, kwargs.get('label_smoothing'), self.entity_cnt)
         self.init()
     
@@ -58,7 +58,7 @@ class ConvR(BaseModel):
         x = self.bn1(x)
         x = F.relu(x)
         x = self.feature_map_drop(x)
-        x = x.sum(dim=1)
+        #x = x.sum(dim=1)
         x = x.view(batch_size, -1)
         x = self.fc(x)
         x = self.hidden_drop(x)

--- a/train.py
+++ b/train.py
@@ -4,17 +4,26 @@ from tqdm import tqdm
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-def train_without_label(data, model, optimizer, device):
+def train_without_label(config, data, model, optimizer, device):
     full_loss = []
+    rel_cnt = config.get('relation_cnt')
     model.train()
     for batch_data in tqdm(data):
         h = batch_data[0].to(device)
         t = batch_data[1].to(device)
         r = batch_data[2].to(device)
+        # 正关系
         optimizer.zero_grad()
         loss, _ = model(h, r, t)
         # loss = loss.mean()
         loss.backward()
         optimizer.step()
-        full_loss.append(loss.item())
+
+        # 逆关系
+        optimizer.zero_grad()
+        loss_rev, _ = model(t, r + rel_cnt, h)
+        # loss = loss.mean()
+        loss_rev.backward()
+        optimizer.step()
+        full_loss.append((loss.item()+loss_rev.item())/2)
     return full_loss


### PR DESCRIPTION
添加头预测的部分代码，通过直接讲关系数量相加在 id 上
修改 model 中的 fc 层的输入，以及模型计算时取消将卷积特征相加
经过调整，模型测试集结果可对齐论文效果（在误差范围内，FB15K 数据集上，mrr = 0.348，相差 0.002）